### PR TITLE
docs: add ruleset dry-run note

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -20,6 +20,8 @@ Follow this process to ensure smooth deployments and catch issues before they re
 
 ### Step-by-Step Workflow
 
+For ruleset validation, use a doc-only change on a dev branch.
+
 #### **1. Development (dev branch)**
 - Create an ephemeral dev branch from `staging`
 - Make changes and commit regularly on the dev branch

--- a/todo.md
+++ b/todo.md
@@ -56,4 +56,4 @@ Getting Production Ready
  - [ ] improve industry detection to 80-90% (requires domain for Clearbit API signup)
  - [x] rebrand to "Workforce Loss Tracker" to match workforceloss.com domain
 
-Last updated: 2026-01-31 14:18 PST (document dev-branch milestone workflow)
+Last updated: 2026-01-31 14:32 PST (add ruleset dry-run note)


### PR DESCRIPTION
## Summary
- add a short note to use a doc-only change for ruleset validation
- update todo timestamp for the workflow dry run