### PR TITLE
ci: run production checks on PRs

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -2,6 +2,8 @@ name: Production CI
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       action:

--- a/todo.md
+++ b/todo.md
@@ -56,4 +56,4 @@ Getting Production Ready
  - [ ] improve industry detection to 80-90% (requires domain for Clearbit API signup)
  - [x] rebrand to "Workforce Loss Tracker" to match workforceloss.com domain
 
-Last updated: 2026-01-31 14:32 PST (add ruleset dry-run note)
+Last updated: 2026-01-31 15:05 PST (enable main PR CI checks)


### PR DESCRIPTION
## Summary
- run Production CI on pull requests targeting main
- keep workflow_dispatch for manual validation